### PR TITLE
fix(webapi): don't mark status as not implemented

### DIFF
--- a/webapi/apiSpStatus.go
+++ b/webapi/apiSpStatus.go
@@ -12,9 +12,8 @@ func apiSpStatus(c echo.Context) error {
 		c,
 		apitypes.ErrSystemTemporarilyDisabled,
 		`
-                                            !!! WE NEVER IMPLEMENTED THIS !!!
-
-This area will contain various information regarding the system and the current state of Storage Provider %s
+		Auth successful, your SP is authorized for Spade and your signature is valid.
+		Storage Provider: %s
     `,
 		ctxMeta.authedActorID.String(),
 	)


### PR DESCRIPTION
# Goal

Our onboarding instructions say to check that you're setup to take deals by caling sp/status endpoint, but the text is very confusing cause it says it's not implemented

# Implementation

Remove the confusing text