### PR TITLE
feat: client library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ mkbin:
 	@mkdir -p bin/
 
 webapi: mkbin genapitypes
-	go build -o bin/spade-webapi ./webapi
+	go build -o bin/spade-webapi ./cmd/webapi
 
 genapitypes:
 	go generate ./apitypes/apierrors.go

--- a/apitypes/core.go
+++ b/apitypes/core.go
@@ -8,17 +8,17 @@ import (
 )
 
 // ResponseEnvelope is the structure wrapping all responses from the deal engine
-type ResponseEnvelope struct {
-	RequestID          string          `json:"request_id,omitempty"`
-	ResponseTime       time.Time       `json:"response_timestamp"`
-	ResponseStateEpoch int64           `json:"response_state_epoch,omitempty"`
-	ResponseCode       int             `json:"response_code"`
-	ErrCode            int             `json:"error_code,omitempty"`
-	ErrSlug            string          `json:"error_slug,omitempty"`
-	ErrLines           []string        `json:"error_lines,omitempty"`
-	InfoLines          []string        `json:"info_lines,omitempty"`
-	ResponseEntries    *int            `json:"response_entries,omitempty"`
-	Response           ResponsePayload `json:"response"`
+type ResponseEnvelope[T ResponsePayload] struct {
+	RequestID          string    `json:"request_id,omitempty"`
+	ResponseTime       time.Time `json:"response_timestamp"`
+	ResponseStateEpoch int64     `json:"response_state_epoch,omitempty"`
+	ResponseCode       int       `json:"response_code"`
+	ErrCode            int       `json:"error_code,omitempty"`
+	ErrSlug            string    `json:"error_slug,omitempty"`
+	ErrLines           []string  `json:"error_lines,omitempty"`
+	InfoLines          []string  `json:"info_lines,omitempty"`
+	ResponseEntries    *int      `json:"response_entries,omitempty"`
+	Response           T         `json:"response"`
 }
 type isResponsePayload struct{}
 

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,200 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	filaddr "github.com/filecoin-project/go-address"
+	"github.com/google/uuid"
+	cid "github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/storacha/spade/apitypes"
+	"github.com/storacha/spade/spid"
+	spid_lotus "github.com/storacha/spade/spid/lotus"
+)
+
+var log = logging.Logger("spade/client")
+
+var DefaultBaseURL, _ = url.Parse("https://api.spade.storacha.network")
+
+// IdentifyFunc produces a FIL-SPID-V0 challenge for authentication.
+type IdentifyFunc func(ctx context.Context, addr filaddr.Address, args url.Values) (spid.Challenge, error)
+
+type clientConfig struct {
+	baseURL    url.URL
+	httpClient *http.Client
+}
+
+type Option func(*clientConfig)
+
+func WithBaseURL(baseURL url.URL) Option {
+	return func(c *clientConfig) {
+		c.baseURL = baseURL
+	}
+}
+
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(c *clientConfig) {
+		c.httpClient = httpClient
+	}
+}
+
+type SpadeClient struct {
+	baseURL         url.URL
+	httpClient      *http.Client
+	identify        IdentifyFunc
+	storageProvider filaddr.Address
+}
+
+func New(storageProvider filaddr.Address, identify IdentifyFunc, options ...Option) *SpadeClient {
+	config := &clientConfig{
+		httpClient: http.DefaultClient,
+		baseURL:    *DefaultBaseURL,
+	}
+	for _, option := range options {
+		option(config)
+	}
+	return &SpadeClient{storageProvider: storageProvider, baseURL: config.baseURL, identify: identify, httpClient: config.httpClient}
+}
+
+func (c *SpadeClient) EligiblePieces(ctx context.Context, options ...EligiblePiecesOption) (apitypes.ResponsePiecesEligible, error) {
+	cfg := EligiblePiecesConfig{}
+	for _, option := range options {
+		option(&cfg)
+	}
+
+	args := url.Values{}
+	if cfg.TenantID != 0 {
+		args.Set("tenant", fmt.Sprintf("%d", cfg.TenantID))
+	}
+	if cfg.Limit > 0 {
+		args.Set("limit", fmt.Sprintf("%d", cfg.Limit))
+	}
+
+	data, err := c.doRequest(ctx, http.MethodGet, "/sp/eligible_pieces", args)
+	var resp apitypes.ResponseEnvelope[apitypes.ResponsePiecesEligible]
+	if err = unmarshalResponseEnvelope(&resp, data); err != nil {
+		return apitypes.ResponsePiecesEligible{}, err
+	}
+	return resp.Response, nil
+}
+
+func (c *SpadeClient) PendingProposals(ctx context.Context) (apitypes.ResponsePendingProposals, error) {
+	args := url.Values{}
+	data, err := c.doRequest(ctx, http.MethodGet, "/sp/pending_proposals", args)
+	var resp apitypes.ResponseEnvelope[apitypes.ResponsePendingProposals]
+	if err = unmarshalResponseEnvelope(&resp, data); err != nil {
+		return apitypes.ResponsePendingProposals{}, err
+	}
+	return resp.Response, nil
+}
+
+func (c *SpadeClient) PieceManifest(ctx context.Context, proposal uuid.UUID) (apitypes.ResponsePieceManifestFR58, error) {
+	args := url.Values{}
+	args.Set("proposal", proposal.String())
+	data, err := c.doRequest(ctx, http.MethodGet, "/sp/piece_manifest", args)
+	var resp apitypes.ResponseEnvelope[apitypes.ResponsePieceManifestFR58]
+	if err = unmarshalResponseEnvelope(&resp, data); err != nil {
+		return apitypes.ResponsePieceManifestFR58{}, err
+	}
+	return resp.Response, nil
+}
+
+func (c *SpadeClient) ReservePiece(ctx context.Context, piece cid.Cid, options ...ReservePieceOption) (apitypes.ResponseDealRequest, error) {
+	cfg := ReservePieceConfig{}
+	for _, option := range options {
+		option(&cfg)
+	}
+
+	args := url.Values{}
+	args.Set("call", "reserve_piece")
+	args.Set("piece_cid", piece.String())
+	if cfg.TenantID != 0 {
+		args.Set("tenant", fmt.Sprintf("%d", cfg.TenantID))
+	}
+	if cfg.TenantPolicy != "" {
+		args.Set("tenant_policy", cfg.TenantPolicy)
+	}
+
+	data, err := c.doRequest(ctx, http.MethodPost, "/sp/invoke", args)
+	if err != nil {
+		return apitypes.ResponseDealRequest{}, err
+	}
+
+	var resp apitypes.ResponseEnvelope[apitypes.ResponseDealRequest]
+	if err = unmarshalResponseEnvelope(&resp, data); err != nil {
+		return apitypes.ResponseDealRequest{}, err
+	}
+
+	return resp.Response, nil
+}
+
+func (c *SpadeClient) doRequest(ctx context.Context, method string, path string, args url.Values) ([]byte, error) {
+	u := c.baseURL.JoinPath(path)
+
+	// if method is GET then put args in URL otherwise in signed auth header
+	if method == http.MethodGet {
+		u.RawQuery = args.Encode()
+		args = url.Values{}
+	} else if method != http.MethodPost {
+		return nil, fmt.Errorf("unsupported method: %s", method)
+	}
+
+	challenge, err := c.identify(ctx, c.storageProvider, args)
+	if err != nil {
+		return nil, fmt.Errorf("creating SPID challenge: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", challenge.String())
+
+	log.Debugw("request", "method", method, "url", u.String(), "args", args)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		log.Errorw("sending request", "method", method, "url", u.String(), "error", err)
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		log.Errorw("unexpected response", "method", method, "url", u.String(), "status", res.StatusCode, "body", string(body))
+		return nil, fmt.Errorf("unexpected response status: %d", res.StatusCode)
+	} else {
+		log.Debugw("response", "method", method, "url", u.String(), "status", res.StatusCode, "body", string(body))
+	}
+
+	return body, nil
+}
+
+func unmarshalResponseEnvelope[T apitypes.ResponsePayload](resp *apitypes.ResponseEnvelope[T], data []byte) error {
+	err := json.Unmarshal(data, resp)
+	if err != nil {
+		return fmt.Errorf("unmarshaling response: %w", err)
+	}
+	if resp.ErrCode != 0 {
+		return fmt.Errorf("API error %d (%s): %s", resp.ErrCode, resp.ErrSlug, strings.Join(resp.ErrLines, "\n"))
+	}
+	return nil
+}
+
+// NewLotusIdentifyFunc creates an IdentifyFunc that uses a Lotus node for
+// challenge generation.
+func NewLotusIdentifyFunc(lotusAPI spid_lotus.LotusBeaconGetterAndWalletSignerClient) IdentifyFunc {
+	return func(ctx context.Context, addr filaddr.Address, args url.Values) (spid.Challenge, error) {
+		return spid_lotus.New(ctx, lotusAPI, addr, args)
+	}
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,9 +2,12 @@ package client_test
 
 import (
 	"context"
-	"crypto/rand"
+	crand "crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"io"
+	"math"
+	"math/rand"
 	"net"
 	"net/url"
 	"testing"
@@ -12,12 +15,15 @@ import (
 
 	"code.riba.cloud/go/toolbox-interplanetary/fil"
 	filaddr "github.com/filecoin-project/go-address"
+	commp "github.com/filecoin-project/go-fil-commp-hashhash"
 	filabi "github.com/filecoin-project/go-state-types/abi"
 	"github.com/google/uuid"
 	cid "github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log/v2"
 	blsgo "github.com/jsign/go-filsigner/bls"
 	"github.com/labstack/echo/v4"
+	"github.com/multiformats/go-multihash"
+	"github.com/storacha/go-piece/pkg/digest"
+	"github.com/storacha/go-piece/pkg/piece"
 	"github.com/storacha/spade/apitypes"
 	"github.com/storacha/spade/client"
 	"github.com/storacha/spade/service"
@@ -29,52 +35,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func randomBytes(t *testing.T, size int) []byte {
-	t.Helper()
-	bytes := make([]byte, size)
-	_, err := rand.Read(bytes)
-	require.NoError(t, err)
-	return bytes
-}
-
-func startSpadeServer(t *testing.T, svc service.SpadeService) url.URL {
-	t.Helper()
-	e := echo.New()
-	e.HideBanner = true
-	e.Listener, _ = net.Listen("tcp", ":0")
-
-	webapi.RegisterRoutes(e, svc)
-
-	go e.Start(":0")
-	t.Cleanup(func() { e.Shutdown(context.Background()) })
-
-	baseURL, err := url.Parse(fmt.Sprintf("http://localhost:%d", e.Listener.Addr().(*net.TCPAddr).Port))
-	require.NoError(t, err)
-	return *baseURL
-}
-
-func mockStorageProvider(t *testing.T) (filaddr.Address, filaddr.Address, []byte) {
-	sp, err := filaddr.NewIDAddress(1000)
-	require.NoError(t, err)
-
-	pk, err := base64.StdEncoding.DecodeString("DHdFHAqEZV/DJ8WlHqHkvxyEGqUfOJd78QwrkqkFrp4=")
-	require.NoError(t, err)
-
-	workerKey, err := blsgo.GetPubKey(pk)
-	require.NoError(t, err)
-
-	return sp, workerKey, pk
-}
-
 func TestClient(t *testing.T) {
-	logging.SetLogLevel("spade/client", "DEBUG")
+	// logging.SetLogLevel("spade/client", "DEBUG")
 
 	sp, workerKey, pk := mockStorageProvider(t)
 
 	svc := mockSpadeService{
-		t:       t,
-		entropy: map[filabi.ChainEpoch][]byte{},
-		workers: map[filaddr.Address]filaddr.Address{sp: workerKey},
+		t:                t,
+		entropy:          map[filabi.ChainEpoch][]byte{},
+		workers:          map[filaddr.Address]filaddr.Address{sp: workerKey},
+		eligiblePieces:   map[filaddr.Address][]service.EligiblePiece{},
+		pendingProposals: map[filaddr.Address][]service.PendingProposal{},
 	}
 
 	baseURL := startSpadeServer(t, &svc)
@@ -102,15 +73,90 @@ func TestClient(t *testing.T) {
 	c := client.New(sp, identify, client.WithBaseURL(baseURL))
 
 	t.Run("eligible pieces", func(t *testing.T) {
-		_, err := c.EligiblePieces(context.Background())
+		eligiblePiece := mockEligiblePiece(t)
+		svc.eligiblePieces[sp] = []service.EligiblePiece{eligiblePiece}
+
+		res, err := c.EligiblePieces(context.Background())
 		require.NoError(t, err)
+		require.Len(t, res, 1)
+		require.Equal(t, eligiblePiece.PieceCid, res[0].PieceCid)
+		require.Equal(t, eligiblePiece.PaddedPieceSize, res[0].PaddedPieceSize)
+		require.Equal(t, eligiblePiece.ClaimingTenant, res[0].ClaimingTenant)
+	})
+
+	t.Run("pending proposals", func(t *testing.T) {
+		undeliveredProposal := mockUndeliveredProposal(t, sp) // should not see in results
+		deliveredProposal := mockDeliveredProposal(t, sp)
+		failedProposal := mockFailedProposal(t, sp)
+		publishedProposal := mockPublishedProposal(t, sp) // should not see in results
+		svc.pendingProposals[sp] = []service.PendingProposal{
+			undeliveredProposal,
+			deliveredProposal,
+			failedProposal,
+			publishedProposal,
+		}
+
+		res, err := c.PendingProposals(context.Background())
+		require.NoError(t, err)
+
+		require.Len(t, res.PendingProposals, 1)
+		require.Equal(t, deliveredProposal.ProposalID, res.PendingProposals[0].ProposalID)
+		require.Equal(t, deliveredProposal.ProposalCid, res.PendingProposals[0].ProposalCid)
+		require.Equal(t, deliveredProposal.HoursRemaining, res.PendingProposals[0].HoursRemaining)
+		require.Equal(t, deliveredProposal.PieceSize, res.PendingProposals[0].PieceSize)
+		require.Equal(t, deliveredProposal.PieceCid, res.PendingProposals[0].PieceCid)
+		require.Equal(t, deliveredProposal.TenantID, res.PendingProposals[0].TenantID)
+		require.Equal(t, deliveredProposal.TenantClient, res.PendingProposals[0].TenantClient)
+		require.Equal(t, deliveredProposal.StartTime, res.PendingProposals[0].StartTime)
+		require.Equal(t, deliveredProposal.StartEpoch, res.PendingProposals[0].StartEpoch)
+
+		require.Len(t, res.RecentFailures, 1)
+		require.Equal(t, failedProposal.ProposalID, res.RecentFailures[0].ProposalID)
+		require.Equal(t, failedProposal.ProposalCid, res.RecentFailures[0].ProposalCid)
+		require.Equal(t, failedProposal.PieceCid, res.RecentFailures[0].PieceCid)
+		require.Equal(t, failedProposal.TenantID, res.RecentFailures[0].TenantID)
+		require.Equal(t, failedProposal.TenantClient, res.RecentFailures[0].TenantClient)
+		require.Equal(t, *failedProposal.Error, res.RecentFailures[0].Error)
+		require.Equal(t, failedProposal.ProposalFailstamp, res.RecentFailures[0].ErrorTimeStamp.UnixNano())
 	})
 }
 
+func startSpadeServer(t *testing.T, svc service.SpadeService) url.URL {
+	t.Helper()
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+	e.Listener, _ = net.Listen("tcp", ":0")
+
+	webapi.RegisterRoutes(e, svc)
+
+	go e.Start(":0")
+	t.Cleanup(func() { e.Shutdown(context.Background()) })
+
+	baseURL, err := url.Parse(fmt.Sprintf("http://localhost:%d", e.Listener.Addr().(*net.TCPAddr).Port))
+	require.NoError(t, err)
+	return *baseURL
+}
+
+func mockStorageProvider(t *testing.T) (filaddr.Address, filaddr.Address, []byte) {
+	sp, err := filaddr.NewIDAddress(uint64(100 + rand.Int63n(10000)))
+	require.NoError(t, err)
+
+	pk, err := base64.StdEncoding.DecodeString("DHdFHAqEZV/DJ8WlHqHkvxyEGqUfOJd78QwrkqkFrp4=")
+	require.NoError(t, err)
+
+	workerKey, err := blsgo.GetPubKey(pk)
+	require.NoError(t, err)
+
+	return sp, workerKey, pk
+}
+
 type mockSpadeService struct {
-	t       *testing.T
-	entropy map[filabi.ChainEpoch][]byte
-	workers map[filaddr.Address]filaddr.Address // sp address -> worker key
+	t                *testing.T
+	entropy          map[filabi.ChainEpoch][]byte
+	workers          map[filaddr.Address]filaddr.Address // sp address -> worker key
+	eligiblePieces   map[filaddr.Address][]service.EligiblePiece
+	pendingProposals map[filaddr.Address][]service.PendingProposal
 }
 
 func (m *mockSpadeService) Authorize(ctx context.Context, req service.Request) (service.Authorization, error) {
@@ -148,11 +194,11 @@ func (m *mockSpadeService) Authorize(ctx context.Context, req service.Request) (
 }
 
 func (m *mockSpadeService) EligiblePieces(ctx context.Context, storageProvider fil.ActorID, options ...service.EligiblePiecesOption) ([]service.EligiblePiece, bool, error) {
-	return nil, false, nil
+	return m.eligiblePieces[storageProvider.AsFilAddr()], false, nil
 }
 
 func (m *mockSpadeService) PendingProposals(ctx context.Context, storageProvider fil.ActorID) ([]service.PendingProposal, error) {
-	panic("unimplemented")
+	return m.pendingProposals[storageProvider.AsFilAddr()], nil
 }
 
 func (m *mockSpadeService) PieceManifest(ctx context.Context, storageProvider fil.ActorID, proposal uuid.UUID) (service.PieceManifest, error) {
@@ -168,3 +214,124 @@ func (m *mockSpadeService) ReservePiece(ctx context.Context, storageProvider fil
 }
 
 var _ service.SpadeService = (*mockSpadeService)(nil)
+
+const sectorSize = 32 * 1024
+
+func mockEligiblePiece(t *testing.T) service.EligiblePiece {
+	t.Helper()
+	unpaddedSize := sectorSize + rand.Int63n(sectorSize/2)
+	piece := randomPiece(t, unpaddedSize)
+	return service.EligiblePiece{
+		PieceID:       1 + rand.Int63n(1000),
+		PieceLog2Size: piece.Height() + uint8(math.Log2(32)),
+		Tenants:       []int16{13},
+		Piece: apitypes.Piece{
+			PieceCid:         piece.Link().String(),
+			PaddedPieceSize:  piece.PaddedSize(),
+			ClaimingTenant:   13,
+			TenantPolicyCid:  randomCID(t).String(),
+			SampleReserveCmd: "test",
+		},
+	}
+}
+
+func mockUndeliveredProposal(t *testing.T, sp filaddr.Address) service.PendingProposal {
+	t.Helper()
+	unpaddedSize := sectorSize + rand.Int63n(sectorSize/2)
+	piece := randomPiece(t, unpaddedSize)
+
+	startEpoch := fil.ClockMainnet.TimeToEpoch(time.Now()) + 900
+	startTime := fil.ClockMainnet.EpochToTime(startEpoch)
+	segmentation := "frc58"
+
+	return service.PendingProposal{
+		ClientID:          fil.MustParseActorString(sp.String()),
+		PieceID:           1 + rand.Int63n(1000),
+		ProposalFailstamp: 0,
+		Error:             nil,
+		ProposalDelivered: nil,
+		IsPublished:       false,
+		PieceLog2Size:     int8(piece.Height()) + int8(math.Log2(32)),
+		DealProposal: apitypes.DealProposal{
+			ProposalID:     uuid.New().String(),
+			ProposalCid:    nil,
+			HoursRemaining: int(time.Until(startTime).Truncate(time.Hour).Hours()),
+			PieceSize:      int64(piece.PaddedSize()),
+			PieceCid:       piece.Link().String(),
+			TenantID:       13,
+			TenantClient:   sp.String(),
+			StartTime:      startTime,
+			StartEpoch:     int64(startEpoch),
+			ImportCmd:      "",
+			Segmentation:   &segmentation,
+			AssemblyCmd:    nil,
+			DataSources:    []string{},
+		},
+	}
+}
+
+func mockDeliveredProposal(t *testing.T, sp filaddr.Address) service.PendingProposal {
+	t.Helper()
+	p := mockUndeliveredProposal(t, sp)
+	now := time.Now()
+	p.ProposalDelivered = &now
+	return p
+}
+
+func mockFailedProposal(t *testing.T, sp filaddr.Address) service.PendingProposal {
+	t.Helper()
+	p := mockDeliveredProposal(t, sp)
+	p.ProposalFailstamp = time.Now().UnixNano()
+	errMsg := "test failed proposal"
+	p.Error = &errMsg
+	return p
+}
+
+func mockPublishedProposal(t *testing.T, sp filaddr.Address) service.PendingProposal {
+	t.Helper()
+	p := mockDeliveredProposal(t, sp)
+	p.IsPublished = true
+	return p
+}
+
+func randomBytes(t *testing.T, size int) []byte {
+	t.Helper()
+	bytes := make([]byte, size)
+	_, err := crand.Read(bytes)
+	require.NoError(t, err)
+	return bytes
+}
+
+func randomCID(t *testing.T) cid.Cid {
+	return cid.NewCidV1(cid.Raw, randomMultihash(t))
+}
+
+func randomMultihash(t *testing.T) multihash.Multihash {
+	bytes := randomBytes(t, 10)
+	digest, err := multihash.Sum(bytes, multihash.SHA2_256, -1)
+	assert.NoError(t, err)
+	return digest
+}
+
+func randomPiece(t *testing.T, unpaddedSize int64) piece.PieceLink {
+	t.Helper()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	dataReader := io.LimitReader(r, unpaddedSize)
+
+	calc := &commp.Calc{}
+	n, err := io.Copy(calc, dataReader)
+	assert.NoError(t, err, "failed copying data into commp.Calc")
+	assert.Equal(t, unpaddedSize, n)
+
+	commP, paddedSize, err := calc.Digest()
+	assert.NoError(t, err, "failed to compute commP")
+
+	pieceDigest, err := digest.FromCommitmentAndSize(commP, uint64(unpaddedSize))
+	assert.NoError(t, err, "failed building piece digest from commP")
+
+	p := piece.FromPieceDigest(pieceDigest)
+	assert.Equal(t, paddedSize, p.PaddedSize())
+
+	return p
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,170 @@
+package client_test
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+
+	"code.riba.cloud/go/toolbox-interplanetary/fil"
+	filaddr "github.com/filecoin-project/go-address"
+	filabi "github.com/filecoin-project/go-state-types/abi"
+	"github.com/google/uuid"
+	cid "github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+	blsgo "github.com/jsign/go-filsigner/bls"
+	"github.com/labstack/echo/v4"
+	"github.com/storacha/spade/apitypes"
+	"github.com/storacha/spade/client"
+	"github.com/storacha/spade/service"
+	"github.com/storacha/spade/spid"
+	spid_args "github.com/storacha/spade/spid/args"
+	"github.com/storacha/spade/spid/signature"
+	"github.com/storacha/spade/webapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func randomBytes(t *testing.T, size int) []byte {
+	t.Helper()
+	bytes := make([]byte, size)
+	_, err := rand.Read(bytes)
+	require.NoError(t, err)
+	return bytes
+}
+
+func startSpadeServer(t *testing.T, svc service.SpadeService) url.URL {
+	t.Helper()
+	e := echo.New()
+	e.HideBanner = true
+	e.Listener, _ = net.Listen("tcp", ":0")
+
+	webapi.RegisterRoutes(e, svc)
+
+	go e.Start(":0")
+	t.Cleanup(func() { e.Shutdown(context.Background()) })
+
+	baseURL, err := url.Parse(fmt.Sprintf("http://localhost:%d", e.Listener.Addr().(*net.TCPAddr).Port))
+	require.NoError(t, err)
+	return *baseURL
+}
+
+func mockStorageProvider(t *testing.T) (filaddr.Address, filaddr.Address, []byte) {
+	sp, err := filaddr.NewIDAddress(1000)
+	require.NoError(t, err)
+
+	pk, err := base64.StdEncoding.DecodeString("DHdFHAqEZV/DJ8WlHqHkvxyEGqUfOJd78QwrkqkFrp4=")
+	require.NoError(t, err)
+
+	workerKey, err := blsgo.GetPubKey(pk)
+	require.NoError(t, err)
+
+	return sp, workerKey, pk
+}
+
+func TestClient(t *testing.T) {
+	logging.SetLogLevel("spade/client", "DEBUG")
+
+	sp, workerKey, pk := mockStorageProvider(t)
+
+	svc := mockSpadeService{
+		t:       t,
+		entropy: map[filabi.ChainEpoch][]byte{},
+		workers: map[filaddr.Address]filaddr.Address{sp: workerKey},
+	}
+
+	baseURL := startSpadeServer(t, &svc)
+
+	signers := map[filaddr.Address]signature.BLSSigner{sp: {PrivateKey: pk}}
+
+	identify := func(ctx context.Context, addr filaddr.Address, rawArgs url.Values) (spid.Challenge, error) {
+		epoch := fil.ClockMainnet.TimeToEpoch(time.Now())
+		entropy := randomBytes(t, 32)
+
+		// set the generated entropy on the mock service so that when it receives
+		// the request it can authorize it
+		svc.entropy[epoch] = entropy
+
+		signer, ok := signers[addr]
+		if !ok {
+			require.FailNowf(t, "missing signer", "address: %s", addr)
+		}
+
+		args, err := spid_args.NewFromValues(signer, entropy, rawArgs)
+		require.NoError(t, err)
+		return spid.New(addr, epoch, args)
+	}
+
+	c := client.New(sp, identify, client.WithBaseURL(baseURL))
+
+	t.Run("eligible pieces", func(t *testing.T) {
+		_, err := c.EligiblePieces(context.Background())
+		require.NoError(t, err)
+	})
+}
+
+type mockSpadeService struct {
+	t       *testing.T
+	entropy map[filabi.ChainEpoch][]byte
+	workers map[filaddr.Address]filaddr.Address // sp address -> worker key
+}
+
+func (m *mockSpadeService) Authorize(ctx context.Context, req service.Request) (service.Authorization, error) {
+	challenge, err := spid.Parse(req.Headers.Get("Authorization"))
+	assert.NoError(m.t, err)
+
+	// typically these are both resolved via filecoin chain state
+	entropy, ok := m.entropy[challenge.Epoch()]
+	if !ok {
+		assert.FailNowf(m.t, "missing entropy for epoch", "epoch: %d", challenge.Epoch())
+	}
+	workerKey, ok := m.workers[challenge.Addr()]
+	if !ok {
+		assert.FailNowf(m.t, "missing worker key address", "sp: %s", challenge.Addr())
+	}
+
+	err = spid.Verify(workerKey, entropy, challenge)
+	assert.NoError(m.t, err)
+
+	sp := fil.MustParseActorString(challenge.Addr().String())
+	signedArgs, err := challenge.Args().Values()
+	assert.NoError(m.t, err)
+
+	now := time.Now()
+
+	return service.Authorization{
+		RequestID:       uuid.New(),
+		SignedArgs:      signedArgs,
+		StateEpoch:      int64(challenge.Epoch()),
+		ProviderID:      sp,
+		ProviderDetails: [4]int16{1, 2, 3, 4},
+		ProviderInfo:    apitypes.SPInfo{},
+		LastPoll:        &now,
+	}, nil
+}
+
+func (m *mockSpadeService) EligiblePieces(ctx context.Context, storageProvider fil.ActorID, options ...service.EligiblePiecesOption) ([]service.EligiblePiece, bool, error) {
+	return nil, false, nil
+}
+
+func (m *mockSpadeService) PendingProposals(ctx context.Context, storageProvider fil.ActorID) ([]service.PendingProposal, error) {
+	panic("unimplemented")
+}
+
+func (m *mockSpadeService) PieceManifest(ctx context.Context, storageProvider fil.ActorID, proposal uuid.UUID) (service.PieceManifest, error) {
+	panic("unimplemented")
+}
+
+func (m *mockSpadeService) RequestError(ctx context.Context, requestID uuid.UUID, code apitypes.APIErrorCode, message string, payload any) error {
+	panic("unimplemented")
+}
+
+func (m *mockSpadeService) ReservePiece(ctx context.Context, storageProvider fil.ActorID, storageProviderInfo apitypes.SPInfo, piece cid.Cid, options ...service.ReservePieceOption) ([]apitypes.TenantReplicationState, error) {
+	panic("unimplemented")
+}
+
+var _ service.SpadeService = (*mockSpadeService)(nil)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -39,8 +39,6 @@ import (
 const sectorSize = 32 * 1024
 
 func TestClient(t *testing.T) {
-	// logging.SetLogLevel("spade/client", "DEBUG")
-
 	sp, workerKey, pk := mockStorageProvider(t)
 
 	svc := mockSpadeService{
@@ -90,7 +88,6 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("pending proposals", func(t *testing.T) {
-
 		undeliveredProposal := mockUndeliveredProposal(t) // should not see in results
 		deliveredProposal := mockDeliveredProposal(t)
 		failedProposal := mockFailedProposal(t)
@@ -140,11 +137,11 @@ func TestClient(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, pieceManifest.PieceCid.String(), res.AggPCidV2)
 		require.Len(t, res.Segments, len(pieceManifest.SegmentCids))
+
 		for i, segment := range pieceManifest.SegmentCids {
 			require.Equal(t, segment.String(), res.Segments[i].PCidV2)
 			require.Len(t, res.Segments[i].Sources, 1)
-			// t.Log(res.Segments[i].PCidV2)
-			// t.Log(res.Segments[i].Sources[0])
+
 			u := new(bytes.Buffer)
 			err := ut.Execute(u, webapi.TemplateParams{SegPCidV2: segment.String()})
 			require.NoError(t, err)
@@ -153,13 +150,13 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("reserve piece", func(t *testing.T) {
-		piece := randomCommP(t, sectorSize+rand.Int63n(sectorSize/2))
+		commP := randomCommP(t, uint64(sectorSize+rand.Intn(sectorSize/2)))
 		replState := mockTenantReplicationState(t)
 		svc.tenantReplicationStates[sp] = map[cid.Cid][]apitypes.TenantReplicationState{
-			piece.PCidV1(): {replState},
+			commP.PCidV1(): {replState},
 		}
 
-		res, err := c.ReservePiece(context.Background(), piece.PCidV1())
+		res, err := c.ReservePiece(context.Background(), commP.PCidV1())
 		require.NoError(t, err)
 		require.Len(t, res.ReplicationStates, 1)
 		require.Equal(t, replState.TenantID, res.ReplicationStates[0].TenantID)
@@ -188,7 +185,7 @@ func startSpadeServer(t *testing.T, svc service.SpadeService) url.URL {
 }
 
 func mockStorageProvider(t *testing.T) (filaddr.Address, filaddr.Address, []byte) {
-	sp, err := filaddr.NewIDAddress(uint64(100 + rand.Int63n(10000)))
+	sp, err := filaddr.NewIDAddress(uint64(100 + rand.Intn(10000)))
 	require.NoError(t, err)
 
 	pk, err := base64.StdEncoding.DecodeString("DHdFHAqEZV/DJ8WlHqHkvxyEGqUfOJd78QwrkqkFrp4=")
@@ -297,15 +294,15 @@ var _ service.SpadeService = (*mockSpadeService)(nil)
 
 func mockEligiblePiece(t *testing.T) service.EligiblePiece {
 	t.Helper()
-	unpaddedSize := sectorSize + rand.Int63n(sectorSize/2)
-	commp := randomCommP(t, unpaddedSize)
+	unpaddedSize := sectorSize + rand.Intn(sectorSize/2)
+	commP := randomCommP(t, uint64(unpaddedSize))
 	return service.EligiblePiece{
 		PieceID:       1 + rand.Int63n(1000),
-		PieceLog2Size: uint8(commp.PieceLog2Size()),
+		PieceLog2Size: uint8(commP.PieceLog2Size()),
 		Tenants:       []int16{13},
 		Piece: apitypes.Piece{
-			PieceCid:         commp.PCidV1().String(),
-			PaddedPieceSize:  uint64(commp.PieceInfo().Size),
+			PieceCid:         commP.PCidV1().String(),
+			PaddedPieceSize:  uint64(commP.PieceInfo().Size),
 			ClaimingTenant:   13,
 			TenantPolicyCid:  randomCID(t).String(),
 			SampleReserveCmd: "test",
@@ -316,11 +313,11 @@ func mockEligiblePiece(t *testing.T) service.EligiblePiece {
 func mockUndeliveredProposal(t *testing.T) service.PendingProposal {
 	t.Helper()
 
-	client, err := filaddr.NewIDAddress(uint64(100 + rand.Int63n(10000)))
+	client, err := filaddr.NewIDAddress(uint64(100 + rand.Intn(10000)))
 	assert.NoError(t, err)
 
-	unpaddedSize := sectorSize + rand.Int63n(sectorSize/2)
-	commp := randomCommP(t, unpaddedSize)
+	unpaddedSize := sectorSize + rand.Intn(sectorSize/2)
+	commP := randomCommP(t, uint64(unpaddedSize))
 
 	startEpoch := fil.ClockMainnet.TimeToEpoch(time.Now()) + 900
 	startTime := fil.ClockMainnet.EpochToTime(startEpoch)
@@ -333,13 +330,13 @@ func mockUndeliveredProposal(t *testing.T) service.PendingProposal {
 		Error:             nil,
 		ProposalDelivered: nil,
 		IsPublished:       false,
-		PieceLog2Size:     commp.PieceLog2Size(),
+		PieceLog2Size:     commP.PieceLog2Size(),
 		DealProposal: apitypes.DealProposal{
 			ProposalID:     uuid.New().String(),
 			ProposalCid:    nil,
 			HoursRemaining: int(time.Until(startTime).Truncate(time.Hour).Hours()),
-			PieceSize:      int64(commp.PieceInfo().Size),
-			PieceCid:       commp.PCidV1().String(),
+			PieceSize:      int64(commP.PieceInfo().Size),
+			PieceCid:       commP.PCidV1().String(),
 			TenantID:       13,
 			TenantClient:   client.String(),
 			StartTime:      startTime,
@@ -378,13 +375,14 @@ func mockPublishedProposal(t *testing.T) service.PendingProposal {
 
 func mockPieceManifest(t *testing.T) service.PieceManifest {
 	t.Helper()
-	commp := randomCommP(t, rand.Int63n(sectorSize))
+	commP := randomCommP(t, uint64(sectorSize+rand.Intn(sectorSize/2)))
 	segmentCids := []cid.Cid{}
 	for range 1 + rand.Intn(4000) {
-		segmentCids = append(segmentCids, randomCID(t))
+		segCommp := randomCommP(t, commp.MinPiecePayload+uint64(rand.Intn(sectorSize)))
+		segmentCids = append(segmentCids, segCommp.PCidV2())
 	}
 	return service.PieceManifest{
-		PieceCid:    commp.PCidV2(),
+		PieceCid:    commP.PCidV2(),
 		SegmentCids: segmentCids,
 		UrlTemplate: "https://tenant.spade.example.com/{{.SegPCidV2}}",
 	}
@@ -392,7 +390,7 @@ func mockPieceManifest(t *testing.T) service.PieceManifest {
 
 func mockTenantReplicationState(t *testing.T) apitypes.TenantReplicationState {
 	t.Helper()
-	client, err := filaddr.NewIDAddress(uint64(100 + rand.Int63n(10000)))
+	client, err := filaddr.NewIDAddress(uint64(100 + rand.Intn(10000)))
 	assert.NoError(t, err)
 	clientstr := client.String()
 	return apitypes.TenantReplicationState{
@@ -422,21 +420,21 @@ func randomMultihash(t *testing.T) multihash.Multihash {
 	return digest
 }
 
-func randomCommP(t *testing.T, unpaddedSize int64) fil.CommP {
+func randomCommP(t *testing.T, unpaddedSize uint64) fil.CommP {
 	t.Helper()
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	dataReader := io.LimitReader(r, unpaddedSize)
+	dataReader := io.LimitReader(r, int64(unpaddedSize))
 
 	calc := &commp.Calc{}
 	n, err := io.Copy(calc, dataReader)
 	assert.NoError(t, err, "failed copying data into commp.Calc")
-	assert.Equal(t, unpaddedSize, n)
+	assert.Equal(t, unpaddedSize, uint64(n))
 
 	commP, _, err := calc.Digest()
 	assert.NoError(t, err, "failed to compute commP")
 
-	cp, err := fil.NewSha2CommP(uint64(unpaddedSize), commP)
+	cp, err := fil.NewSha2CommP(unpaddedSize, commP)
 	assert.NoError(t, err, "failed to create CommP")
 	return cp
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,16 +1,17 @@
 package client_test
 
 import (
+	"bytes"
 	"context"
 	crand "crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"io"
-	"math"
 	"math/rand"
 	"net"
 	"net/url"
 	"testing"
+	"text/template"
 	"time"
 
 	"code.riba.cloud/go/toolbox-interplanetary/fil"
@@ -22,10 +23,9 @@ import (
 	blsgo "github.com/jsign/go-filsigner/bls"
 	"github.com/labstack/echo/v4"
 	"github.com/multiformats/go-multihash"
-	"github.com/storacha/go-piece/pkg/digest"
-	"github.com/storacha/go-piece/pkg/piece"
 	"github.com/storacha/spade/apitypes"
 	"github.com/storacha/spade/client"
+	"github.com/storacha/spade/internal/filtypes"
 	"github.com/storacha/spade/service"
 	"github.com/storacha/spade/spid"
 	spid_args "github.com/storacha/spade/spid/args"
@@ -35,17 +35,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// sectorSize is a smol sector for testing, 32 KiB.
+const sectorSize = 32 * 1024
+
 func TestClient(t *testing.T) {
 	// logging.SetLogLevel("spade/client", "DEBUG")
 
 	sp, workerKey, pk := mockStorageProvider(t)
 
 	svc := mockSpadeService{
-		t:                t,
-		entropy:          map[filabi.ChainEpoch][]byte{},
-		workers:          map[filaddr.Address]filaddr.Address{sp: workerKey},
-		eligiblePieces:   map[filaddr.Address][]service.EligiblePiece{},
-		pendingProposals: map[filaddr.Address][]service.PendingProposal{},
+		t:                       t,
+		entropy:                 map[filabi.ChainEpoch][]byte{},
+		workers:                 map[filaddr.Address]filaddr.Address{sp: workerKey},
+		eligiblePieces:          map[filaddr.Address][]service.EligiblePiece{},
+		pendingProposals:        map[filaddr.Address][]service.PendingProposal{},
+		pieceManifests:          map[filaddr.Address]map[string]service.PieceManifest{},
+		tenantReplicationStates: map[filaddr.Address]map[cid.Cid][]apitypes.TenantReplicationState{},
 	}
 
 	baseURL := startSpadeServer(t, &svc)
@@ -62,11 +67,11 @@ func TestClient(t *testing.T) {
 
 		signer, ok := signers[addr]
 		if !ok {
-			require.FailNowf(t, "missing signer", "address: %s", addr)
+			assert.FailNowf(t, "missing signer", "address: %s", addr)
 		}
 
 		args, err := spid_args.NewFromValues(signer, entropy, rawArgs)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		return spid.New(addr, epoch, args)
 	}
 
@@ -85,10 +90,11 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("pending proposals", func(t *testing.T) {
-		undeliveredProposal := mockUndeliveredProposal(t, sp) // should not see in results
-		deliveredProposal := mockDeliveredProposal(t, sp)
-		failedProposal := mockFailedProposal(t, sp)
-		publishedProposal := mockPublishedProposal(t, sp) // should not see in results
+
+		undeliveredProposal := mockUndeliveredProposal(t) // should not see in results
+		deliveredProposal := mockDeliveredProposal(t)
+		failedProposal := mockFailedProposal(t)
+		publishedProposal := mockPublishedProposal(t) // should not see in results
 		svc.pendingProposals[sp] = []service.PendingProposal{
 			undeliveredProposal,
 			deliveredProposal,
@@ -118,6 +124,49 @@ func TestClient(t *testing.T) {
 		require.Equal(t, failedProposal.TenantClient, res.RecentFailures[0].TenantClient)
 		require.Equal(t, *failedProposal.Error, res.RecentFailures[0].Error)
 		require.Equal(t, failedProposal.ProposalFailstamp, res.RecentFailures[0].ErrorTimeStamp.UnixNano())
+	})
+
+	t.Run("piece manifest", func(t *testing.T) {
+		proposal := uuid.New()
+		pieceManifest := mockPieceManifest(t)
+		svc.pieceManifests[sp] = map[string]service.PieceManifest{
+			proposal.String(): pieceManifest,
+		}
+
+		ut, err := template.New("url").Parse(pieceManifest.UrlTemplate)
+		require.NoError(t, err)
+
+		res, err := c.PieceManifest(context.Background(), proposal)
+		require.NoError(t, err)
+		require.Equal(t, pieceManifest.PieceCid.String(), res.AggPCidV2)
+		require.Len(t, res.Segments, len(pieceManifest.SegmentCids))
+		for i, segment := range pieceManifest.SegmentCids {
+			require.Equal(t, segment.String(), res.Segments[i].PCidV2)
+			require.Len(t, res.Segments[i].Sources, 1)
+			// t.Log(res.Segments[i].PCidV2)
+			// t.Log(res.Segments[i].Sources[0])
+			u := new(bytes.Buffer)
+			err := ut.Execute(u, webapi.TemplateParams{SegPCidV2: segment.String()})
+			require.NoError(t, err)
+			require.Equal(t, u.String(), res.Segments[i].Sources[0])
+		}
+	})
+
+	t.Run("reserve piece", func(t *testing.T) {
+		piece := randomCommP(t, sectorSize+rand.Int63n(sectorSize/2))
+		replState := mockTenantReplicationState(t)
+		svc.tenantReplicationStates[sp] = map[cid.Cid][]apitypes.TenantReplicationState{
+			piece.PCidV1(): {replState},
+		}
+
+		res, err := c.ReservePiece(context.Background(), piece.PCidV1())
+		require.NoError(t, err)
+		require.Len(t, res.ReplicationStates, 1)
+		require.Equal(t, replState.TenantID, res.ReplicationStates[0].TenantID)
+		require.Equal(t, *replState.TenantClient, *res.ReplicationStates[0].TenantClient)
+		require.Equal(t, replState.MaxInFlightBytes, res.ReplicationStates[0].MaxInFlightBytes)
+		require.Equal(t, replState.SpInFlightBytes, res.ReplicationStates[0].SpInFlightBytes)
+		// other fields are zero-valued
 	})
 }
 
@@ -152,11 +201,13 @@ func mockStorageProvider(t *testing.T) (filaddr.Address, filaddr.Address, []byte
 }
 
 type mockSpadeService struct {
-	t                *testing.T
-	entropy          map[filabi.ChainEpoch][]byte
-	workers          map[filaddr.Address]filaddr.Address // sp address -> worker key
-	eligiblePieces   map[filaddr.Address][]service.EligiblePiece
-	pendingProposals map[filaddr.Address][]service.PendingProposal
+	t                       *testing.T
+	entropy                 map[filabi.ChainEpoch][]byte
+	workers                 map[filaddr.Address]filaddr.Address // sp address -> worker key
+	eligiblePieces          map[filaddr.Address][]service.EligiblePiece
+	pendingProposals        map[filaddr.Address][]service.PendingProposal
+	pieceManifests          map[filaddr.Address]map[string]service.PieceManifest              // sp address -> proposal UUID -> manifest
+	tenantReplicationStates map[filaddr.Address]map[cid.Cid][]apitypes.TenantReplicationState // sp address -> piece CID -> states
 }
 
 func (m *mockSpadeService) Authorize(ctx context.Context, req service.Request) (service.Authorization, error) {
@@ -182,14 +233,26 @@ func (m *mockSpadeService) Authorize(ctx context.Context, req service.Request) (
 
 	now := time.Now()
 
+	// copied from [apitypes.SPInfo] because it's a pointer to an inline type, FML
+	peerInfo := struct {
+		Protos map[string]struct{}    `json:"libp2p_protocols"`
+		Meta   map[string]interface{} `json:"meta"`
+	}{
+		Protos: map[string]struct{}{
+			filtypes.StorageProposalV120: {},
+		},
+	}
+
 	return service.Authorization{
 		RequestID:       uuid.New(),
 		SignedArgs:      signedArgs,
 		StateEpoch:      int64(challenge.Epoch()),
 		ProviderID:      sp,
 		ProviderDetails: [4]int16{1, 2, 3, 4},
-		ProviderInfo:    apitypes.SPInfo{},
-		LastPoll:        &now,
+		ProviderInfo: apitypes.SPInfo{
+			PeerInfo: &peerInfo,
+		},
+		LastPoll: &now,
 	}, nil
 }
 
@@ -202,32 +265,47 @@ func (m *mockSpadeService) PendingProposals(ctx context.Context, storageProvider
 }
 
 func (m *mockSpadeService) PieceManifest(ctx context.Context, storageProvider fil.ActorID, proposal uuid.UUID) (service.PieceManifest, error) {
-	panic("unimplemented")
+	manifests, ok := m.pieceManifests[storageProvider.AsFilAddr()]
+	if !ok {
+		assert.FailNowf(m.t, "missing manifest", "sp: %s", storageProvider)
+	}
+	manifest, ok := manifests[proposal.String()]
+	if !ok {
+		assert.FailNowf(m.t, "missing manifest for proposal", "sp: %s, proposal: %s", storageProvider, proposal)
+	}
+	return manifest, nil
 }
 
 func (m *mockSpadeService) RequestError(ctx context.Context, requestID uuid.UUID, code apitypes.APIErrorCode, message string, payload any) error {
-	panic("unimplemented")
+	m.t.Logf("RequestError: requestID=%s, code=%d, message=%s, payload=%v", requestID, code, message, payload)
+	return nil
 }
 
 func (m *mockSpadeService) ReservePiece(ctx context.Context, storageProvider fil.ActorID, storageProviderInfo apitypes.SPInfo, piece cid.Cid, options ...service.ReservePieceOption) ([]apitypes.TenantReplicationState, error) {
-	panic("unimplemented")
+	states, ok := m.tenantReplicationStates[storageProvider.AsFilAddr()]
+	if !ok {
+		assert.FailNowf(m.t, "missing replication states", "sp: %s", storageProvider)
+	}
+	repStates, ok := states[piece]
+	if !ok {
+		assert.FailNowf(m.t, "missing replication states for piece", "sp: %s, piece: %s", storageProvider, piece)
+	}
+	return repStates, nil
 }
 
 var _ service.SpadeService = (*mockSpadeService)(nil)
 
-const sectorSize = 32 * 1024
-
 func mockEligiblePiece(t *testing.T) service.EligiblePiece {
 	t.Helper()
 	unpaddedSize := sectorSize + rand.Int63n(sectorSize/2)
-	piece := randomPiece(t, unpaddedSize)
+	commp := randomCommP(t, unpaddedSize)
 	return service.EligiblePiece{
 		PieceID:       1 + rand.Int63n(1000),
-		PieceLog2Size: piece.Height() + uint8(math.Log2(32)),
+		PieceLog2Size: uint8(commp.PieceLog2Size()),
 		Tenants:       []int16{13},
 		Piece: apitypes.Piece{
-			PieceCid:         piece.Link().String(),
-			PaddedPieceSize:  piece.PaddedSize(),
+			PieceCid:         commp.PCidV1().String(),
+			PaddedPieceSize:  uint64(commp.PieceInfo().Size),
 			ClaimingTenant:   13,
 			TenantPolicyCid:  randomCID(t).String(),
 			SampleReserveCmd: "test",
@@ -235,31 +313,35 @@ func mockEligiblePiece(t *testing.T) service.EligiblePiece {
 	}
 }
 
-func mockUndeliveredProposal(t *testing.T, sp filaddr.Address) service.PendingProposal {
+func mockUndeliveredProposal(t *testing.T) service.PendingProposal {
 	t.Helper()
+
+	client, err := filaddr.NewIDAddress(uint64(100 + rand.Int63n(10000)))
+	assert.NoError(t, err)
+
 	unpaddedSize := sectorSize + rand.Int63n(sectorSize/2)
-	piece := randomPiece(t, unpaddedSize)
+	commp := randomCommP(t, unpaddedSize)
 
 	startEpoch := fil.ClockMainnet.TimeToEpoch(time.Now()) + 900
 	startTime := fil.ClockMainnet.EpochToTime(startEpoch)
 	segmentation := "frc58"
 
 	return service.PendingProposal{
-		ClientID:          fil.MustParseActorString(sp.String()),
+		ClientID:          fil.MustParseActorString(client.String()),
 		PieceID:           1 + rand.Int63n(1000),
 		ProposalFailstamp: 0,
 		Error:             nil,
 		ProposalDelivered: nil,
 		IsPublished:       false,
-		PieceLog2Size:     int8(piece.Height()) + int8(math.Log2(32)),
+		PieceLog2Size:     commp.PieceLog2Size(),
 		DealProposal: apitypes.DealProposal{
 			ProposalID:     uuid.New().String(),
 			ProposalCid:    nil,
 			HoursRemaining: int(time.Until(startTime).Truncate(time.Hour).Hours()),
-			PieceSize:      int64(piece.PaddedSize()),
-			PieceCid:       piece.Link().String(),
+			PieceSize:      int64(commp.PieceInfo().Size),
+			PieceCid:       commp.PCidV1().String(),
 			TenantID:       13,
-			TenantClient:   sp.String(),
+			TenantClient:   client.String(),
 			StartTime:      startTime,
 			StartEpoch:     int64(startEpoch),
 			ImportCmd:      "",
@@ -270,28 +352,55 @@ func mockUndeliveredProposal(t *testing.T, sp filaddr.Address) service.PendingPr
 	}
 }
 
-func mockDeliveredProposal(t *testing.T, sp filaddr.Address) service.PendingProposal {
+func mockDeliveredProposal(t *testing.T) service.PendingProposal {
 	t.Helper()
-	p := mockUndeliveredProposal(t, sp)
+	p := mockUndeliveredProposal(t)
 	now := time.Now()
 	p.ProposalDelivered = &now
 	return p
 }
 
-func mockFailedProposal(t *testing.T, sp filaddr.Address) service.PendingProposal {
+func mockFailedProposal(t *testing.T) service.PendingProposal {
 	t.Helper()
-	p := mockDeliveredProposal(t, sp)
+	p := mockDeliveredProposal(t)
 	p.ProposalFailstamp = time.Now().UnixNano()
 	errMsg := "test failed proposal"
 	p.Error = &errMsg
 	return p
 }
 
-func mockPublishedProposal(t *testing.T, sp filaddr.Address) service.PendingProposal {
+func mockPublishedProposal(t *testing.T) service.PendingProposal {
 	t.Helper()
-	p := mockDeliveredProposal(t, sp)
+	p := mockDeliveredProposal(t)
 	p.IsPublished = true
 	return p
+}
+
+func mockPieceManifest(t *testing.T) service.PieceManifest {
+	t.Helper()
+	commp := randomCommP(t, rand.Int63n(sectorSize))
+	segmentCids := []cid.Cid{}
+	for range 1 + rand.Intn(4000) {
+		segmentCids = append(segmentCids, randomCID(t))
+	}
+	return service.PieceManifest{
+		PieceCid:    commp.PCidV2(),
+		SegmentCids: segmentCids,
+		UrlTemplate: "https://tenant.spade.example.com/{{.SegPCidV2}}",
+	}
+}
+
+func mockTenantReplicationState(t *testing.T) apitypes.TenantReplicationState {
+	t.Helper()
+	client, err := filaddr.NewIDAddress(uint64(100 + rand.Int63n(10000)))
+	assert.NoError(t, err)
+	clientstr := client.String()
+	return apitypes.TenantReplicationState{
+		TenantID:         13,
+		TenantClient:     &clientstr,
+		MaxInFlightBytes: 1 + rand.Int63n(1024*1024*1024*32),
+		SpInFlightBytes:  1 + rand.Int63n(1024*1024*1024*32),
+	}
 }
 
 func randomBytes(t *testing.T, size int) []byte {
@@ -313,7 +422,7 @@ func randomMultihash(t *testing.T) multihash.Multihash {
 	return digest
 }
 
-func randomPiece(t *testing.T, unpaddedSize int64) piece.PieceLink {
+func randomCommP(t *testing.T, unpaddedSize int64) fil.CommP {
 	t.Helper()
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -324,14 +433,10 @@ func randomPiece(t *testing.T, unpaddedSize int64) piece.PieceLink {
 	assert.NoError(t, err, "failed copying data into commp.Calc")
 	assert.Equal(t, unpaddedSize, n)
 
-	commP, paddedSize, err := calc.Digest()
+	commP, _, err := calc.Digest()
 	assert.NoError(t, err, "failed to compute commP")
 
-	pieceDigest, err := digest.FromCommitmentAndSize(commP, uint64(unpaddedSize))
-	assert.NoError(t, err, "failed building piece digest from commP")
-
-	p := piece.FromPieceDigest(pieceDigest)
-	assert.Equal(t, paddedSize, p.PaddedSize())
-
-	return p
+	cp, err := fil.NewSha2CommP(uint64(unpaddedSize), commP)
+	assert.NoError(t, err, "failed to create CommP")
+	return cp
 }

--- a/client/options.go
+++ b/client/options.go
@@ -1,0 +1,45 @@
+package client
+
+type EligiblePiecesOption = func(*EligiblePiecesConfig)
+
+type EligiblePiecesConfig struct {
+	TenantID int16
+	Limit    uint64
+}
+
+func WithEligiblePiecesTenantID(tenantID int16) EligiblePiecesOption {
+	return func(opts *EligiblePiecesConfig) {
+		opts.TenantID = tenantID
+	}
+}
+
+func WithEligiblePiecesLimit(limit uint64) EligiblePiecesOption {
+	return func(opts *EligiblePiecesConfig) {
+		opts.Limit = limit
+	}
+}
+
+type ReservePieceOption = func(*ReservePieceConfig)
+
+type ReservePieceConfig struct {
+	TenantID     int16
+	TenantPolicy string
+}
+
+// WithReservePieceTenantID sets an optional tenant ID the piece should be
+// reserved with.
+func WithReservePieceTenantID(tenantID int16) ReservePieceOption {
+	return func(opts *ReservePieceConfig) {
+		opts.TenantID = tenantID
+	}
+}
+
+// WithReservePieceTenantPolicy sets an optional tenant policy string to
+// validate against when reserving the piece. Note: if the chosen tenant has a
+// policy configured, this must match. i.e. this is mandatory for tenants that
+// have a policy set.
+func WithReservePieceTenantPolicy(tenantPolicy string) ReservePieceOption {
+	return func(opts *ReservePieceConfig) {
+		opts.TenantPolicy = tenantPolicy
+	}
+}

--- a/cmd/webapi/main.go
+++ b/cmd/webapi/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/storacha/spade/webapi"
+
+func main() {
+	webapi.Start()
+}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/filecoin-project/go-address v1.2.0
 	github.com/filecoin-project/go-cbor-util v0.0.2
 	github.com/filecoin-project/go-data-segment v0.0.1
+	github.com/filecoin-project/go-fil-commp-hashhash v0.2.0
 	github.com/filecoin-project/go-state-types v0.17.0
 	github.com/filecoin-project/lotus v1.34.1
 	github.com/fxamacker/cbor/v2 v2.7.0
@@ -30,6 +31,7 @@ require (
 	github.com/ipfs/go-cid v0.5.0
 	github.com/ipfs/go-ipld-cbor v0.2.1
 	github.com/ipfs/go-log/v2 v2.6.0
+	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/jsign/go-filsigner v0.4.1
 	github.com/labstack/echo/v4 v4.11.4
@@ -38,6 +40,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/multiformats/go-multiaddr v0.16.1
 	github.com/multiformats/go-multihash v0.2.3
+	github.com/storacha/go-piece v0.0.0-20250604155842-600f0e474760
 	github.com/stretchr/testify v1.10.0
 	github.com/whyrusleeping/cbor-gen v0.3.1
 	golang.org/x/sync v0.16.0
@@ -136,7 +139,6 @@ require (
 	github.com/ipld/go-codec-dagpb v1.7.0 // indirect
 	github.com/ipld/go-ipld-prime v0.21.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.14.3 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/multiformats/go-multiaddr v0.16.1
 	github.com/multiformats/go-multihash v0.2.3
-	github.com/storacha/go-piece v0.0.0-20250604155842-600f0e474760
 	github.com/stretchr/testify v1.10.0
 	github.com/whyrusleeping/cbor-gen v0.3.1
 	golang.org/x/sync v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -994,8 +994,6 @@ github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7A
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/storacha/go-piece v0.0.0-20250604155842-600f0e474760 h1:oK7CV6hSA8mnc6eEkN/rh8XowN1tndinomlPRatza2M=
-github.com/storacha/go-piece v0.0.0-20250604155842-600f0e474760/go.mod h1:lV3s4aCpSZn9srVjfDTsIAqx3MbO8Y/7JH2M/esSZcM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/go.sum
+++ b/go.sum
@@ -994,6 +994,8 @@ github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7A
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/storacha/go-piece v0.0.0-20250604155842-600f0e474760 h1:oK7CV6hSA8mnc6eEkN/rh8XowN1tndinomlPRatza2M=
+github.com/storacha/go-piece v0.0.0-20250604155842-600f0e474760/go.mod h1:lV3s4aCpSZn9srVjfDTsIAqx3MbO8Y/7JH2M/esSZcM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/webapi/apiSpInvoke.go
+++ b/webapi/apiSpInvoke.go
@@ -1,4 +1,4 @@
-package main
+package webapi
 
 import (
 	"errors"

--- a/webapi/apiSpListEligible.go
+++ b/webapi/apiSpListEligible.go
@@ -1,4 +1,4 @@
-package main //nolint:revive
+package webapi //nolint:revive
 
 import (
 	"fmt"

--- a/webapi/apiSpPendingReservations.go
+++ b/webapi/apiSpPendingReservations.go
@@ -1,4 +1,4 @@
-package main
+package webapi
 
 import (
 	"fmt"

--- a/webapi/apiSpPieceManifest.go
+++ b/webapi/apiSpPieceManifest.go
@@ -1,4 +1,4 @@
-package main
+package webapi
 
 import (
 	"bytes"

--- a/webapi/apiSpStatus.go
+++ b/webapi/apiSpStatus.go
@@ -1,4 +1,4 @@
-package main
+package webapi
 
 import (
 	"github.com/labstack/echo/v4"

--- a/webapi/auth.go
+++ b/webapi/auth.go
@@ -1,4 +1,4 @@
-package main
+package webapi
 
 import (
 	"context"
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/storacha/spade/apitypes"
-	"github.com/storacha/spade/internal/app"
 	"github.com/storacha/spade/service"
 	"github.com/storacha/spade/spid"
 )
@@ -23,7 +22,7 @@ func NewSpIDAuthMiddleware(svc service.AuthorizationService) echo.MiddlewareFunc
 
 func spidAuth(next echo.HandlerFunc, svc service.AuthorizationService) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		ctx, _, _, _ := app.UnpackCtx(c.Request().Context())
+		ctx := c.Request().Context()
 
 		// the SP portion does not accept body payloads
 		if b := c.Request().Body; b != nil && c.Request().ContentLength != 0 {
@@ -65,7 +64,6 @@ func spidAuth(next echo.HandlerFunc, svc service.AuthorizationService) echo.Hand
 		c.Response().Header().Set("X-SPADE-REQUEST-UUID", auth.RequestID.String())
 
 		c.Set("♠️", metaContext{
-			GlobalContext:    app.GetGlobalCtx(ctx),
 			requestID:        auth.RequestID,
 			stateEpoch:       auth.StateEpoch,
 			authedActorID:    auth.ProviderID,
@@ -83,7 +81,6 @@ func spidAuth(next echo.HandlerFunc, svc service.AuthorizationService) echo.Hand
 }
 
 type metaContext struct {
-	app.GlobalContext
 	requestID        uuid.UUID
 	authedActorID    fil.ActorID
 	stateEpoch       int64

--- a/webapi/main.go
+++ b/webapi/main.go
@@ -1,4 +1,4 @@
-package main
+package webapi
 
 import (
 	"context"
@@ -41,7 +41,7 @@ func setup(ctx context.Context) *echo.Echo {
 	svc := pg.New(db, gCtx.LotusAPI)
 
 	// routes
-	registerRoutes(e, svc)
+	RegisterRoutes(e, svc)
 
 	//
 	// Housekeeping
@@ -72,7 +72,7 @@ func (rawJSONSerializer) Deserialize(c echo.Context, i interface{}) error {
 	return defJSONSerializer.Deserialize(c, i)
 }
 
-func main() {
+func Start() {
 	cmdName := app.AppName + "-webapi"
 	log := logging.Logger(fmt.Sprintf("%s(%d)", cmdName, os.Getpid()))
 

--- a/webapi/routes.go
+++ b/webapi/routes.go
@@ -1,4 +1,4 @@
-package main
+package webapi
 
 import (
 	"github.com/labstack/echo/v4"
@@ -7,7 +7,7 @@ import (
 
 // This lists in one place all recognized routes & parameters
 // FIXME - we should make an openapi or something for this...
-func registerRoutes(e *echo.Echo, svc service.SpadeService) {
+func RegisterRoutes(e *echo.Echo, svc service.SpadeService) {
 	spRoutes := e.Group("/sp", NewSpIDAuthMiddleware(svc))
 
 	//

--- a/webapi/util.go
+++ b/webapi/util.go
@@ -1,4 +1,4 @@
-package main
+package webapi
 
 import (
 	"fmt"
@@ -61,7 +61,7 @@ func retPayloadAnnotated(c echo.Context, log service.ErrorLogger, httpCode int, 
 		}
 	}
 
-	r := apitypes.ResponseEnvelope{
+	r := apitypes.ResponseEnvelope[apitypes.ResponsePayload]{
 		RequestID:          c.Request().Header.Get("X-SPADE-REQUEST-UUID"),
 		ResponseStateEpoch: int64(ctxMeta.stateEpoch),
 		ResponseTime:       time.Now(),


### PR DESCRIPTION
Adds a client library and tests for the Spade API. It is loosely based on https://github.com/storacha/filecoin-spade-client/blob/main/pkg/spadeclient/spadeclient.go

~~TODO: test `PieceManifest` and `ReservePiece` calls.~~

refs storacha/spade-agent#7 